### PR TITLE
Comment tweaks and delete fixes.

### DIFF
--- a/dnsone.go
+++ b/dnsone.go
@@ -18,9 +18,7 @@ func (s *ChallSrv) AddDNSOneChallenge(host, content string) {
 func (s *ChallSrv) DeleteDNSOneChallenge(host string) {
 	s.challMu.Lock()
 	defer s.challMu.Unlock()
-	if _, ok := s.dnsOne[host]; ok {
-		delete(s.dnsOne, host)
-	}
+	delete(s.dnsOne, host)
 }
 
 // GetDNSOneChallenge returns a slice of TXT record values for the given host.

--- a/httpone.go
+++ b/httpone.go
@@ -49,7 +49,7 @@ func selfSignedCert() tls.Certificate {
 		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
 		BasicConstraintsValid: true,
-		IsCA:                  true,
+		IsCA: true,
 	}
 
 	der, err := x509.CreateCertificate(rand.Reader, template, template, key.Public(), key)
@@ -75,9 +75,7 @@ func (s *ChallSrv) AddHTTPOneChallenge(token, content string) {
 func (s *ChallSrv) DeleteHTTPOneChallenge(token string) {
 	s.challMu.Lock()
 	defer s.challMu.Unlock()
-	if _, ok := s.httpOne[token]; ok {
-		delete(s.httpOne, token)
-	}
+	delete(s.httpOne, token)
 }
 
 // GetHTTPOneChallenge returns the HTTP-01 challenge content for the given token
@@ -101,9 +99,7 @@ func (s *ChallSrv) AddHTTPRedirect(path, targetURL string) {
 func (s *ChallSrv) DeleteHTTPRedirect(path string) {
 	s.challMu.Lock()
 	defer s.challMu.Unlock()
-	if _, ok := s.redirects[path]; ok {
-		delete(s.redirects, path)
-	}
+	delete(s.redirects, path)
 }
 
 // GetHTTPRedirect returns the redirect target for the given path
@@ -149,16 +145,14 @@ type challHTTPServer struct {
 
 // ListenAndServe for a challHTTPServer will call the underlying http.Server's
 // ListenAndServeTLS if the server has a non-nil TLSConfig, otherwise it will
-// use the underlying http.Server's ListenAndServe(). This allos for
+// use the underlying http.Server's ListenAndServe(). This allows for
 // a challHTTPServer to be both a normal HTTP based HTTP-01 challenge response
 // server in one configuration (nil TLSConfig) and an HTTPS based HTTP-01
 // challenge response server useful for redirect targets in another
 // configuration.
 func (c challHTTPServer) ListenAndServe() error {
-	// If the server has a TLSConfig then use ListenAndServeTLS with empty
-	// certfile/keyfile arguments. This will use the self-signed certificate we
-	// issued when constructing the TLSConfig in `httpOneServer`.
 	if c.Server.TLSConfig != nil {
+		// This will use the certificate and key from TLSConfig.
 		return c.Server.ListenAndServeTLS("", "")
 	}
 	// Otherwise use HTTP

--- a/mockdns.go
+++ b/mockdns.go
@@ -1,7 +1,6 @@
 package challtestsrv
 
 import (
-	"fmt"
 	"strings"
 )
 
@@ -58,9 +57,7 @@ func (s *ChallSrv) DeleteDNSARecord(host string) {
 	if !strings.HasSuffix(host, ".") {
 		host = host + "."
 	}
-	if _, ok := s.dnsMocks.aRecords[host]; ok {
-		delete(s.dnsMocks.aRecords, host)
-	}
+	delete(s.dnsMocks.aRecords, host)
 }
 
 // GetDNSARecord returns a slice of IPv4 addresses (in string form) that will be
@@ -93,9 +90,7 @@ func (s *ChallSrv) DeleteDNSAAAARecord(host string) {
 	if !strings.HasSuffix(host, ".") {
 		host = host + "."
 	}
-	if _, ok := s.dnsMocks.aaaaRecords[host]; ok {
-		delete(s.dnsMocks.aaaaRecords, host)
-	}
+	delete(s.dnsMocks.aaaaRecords, host)
 }
 
 // GetDNSAAAARecord returns a slice of IPv6 addresses (in string form) that will
@@ -117,7 +112,6 @@ func (s *ChallSrv) AddDNSCAARecord(host string, policies []MockCAAPolicy) {
 	if !strings.HasSuffix(host, ".") {
 		host = host + "."
 	}
-	fmt.Printf("Adding %#v for %q\n", policies, host)
 	s.dnsMocks.caaRecords[host] = append(s.dnsMocks.caaRecords[host], policies...)
 }
 
@@ -129,9 +123,7 @@ func (s *ChallSrv) DeleteDNSCAARecord(host string) {
 	if !strings.HasSuffix(host, ".") {
 		host = host + "."
 	}
-	if _, ok := s.dnsMocks.caaRecords[host]; ok {
-		delete(s.dnsMocks.caaRecords, host)
-	}
+	delete(s.dnsMocks.caaRecords, host)
 }
 
 // GetDNSCAARecord returns a slice of mock CAA policies that will

--- a/tlsalpnone.go
+++ b/tlsalpnone.go
@@ -35,9 +35,7 @@ func (s *ChallSrv) AddTLSALPNChallenge(host, content string) {
 func (s *ChallSrv) DeleteTLSALPNChallenge(host string) {
 	s.challMu.Lock()
 	defer s.challMu.Unlock()
-	if _, ok := s.tlsALPNOne[host]; ok {
-		delete(s.tlsALPNOne, host)
-	}
+	delete(s.tlsALPNOne, host)
 }
 
 // GetTLSALPNChallenge checks the s.tlsALPNOne map for the given host.
@@ -99,9 +97,8 @@ func (c challTLSServer) Shutdown() error {
 }
 
 func (c challTLSServer) ListenAndServe() error {
-	// We never want to serve a plain cert so leave certFile and keyFile
-	// empty. If we don't know the SNI name/ALPN fails the handshake will
-	// fail anyway.
+	// Since we set TLSConfig.GetCertificate, the certfile and keyFile arguments
+	// are ignored and we leave them blank.
 	return c.Server.ListenAndServeTLS("", "")
 }
 


### PR DESCRIPTION
Fix some style/clarity things in the comments.

Also, remove the "if" guards around several delete statements. The
delete builtin is a no-op if the field doesn't exist, so we don't need
those guards.