### PR TITLE
Track challenge server request history.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,16 @@ value `"bbb"`, defer cleaning it up again:
   defer challSrv.DeleteHTTPOneChallenge("_acme-challenge.example.com.")
 ```
 
+Get the history of requests processed by the challenge server:
+```
+requestHistory := challSrv.RequestHistory()
+```
+
+Clear the history of requests:
+```
+challSrv.ClearRequestHistory()
+```
+
 Stop the Challenge server and subservers:
 ```
   // Shutdown the Challenge server

--- a/README.md
+++ b/README.md
@@ -50,14 +50,14 @@ value `"bbb"`, defer cleaning it up again:
   defer challSrv.DeleteHTTPOneChallenge("_acme-challenge.example.com.")
 ```
 
-Get the history of requests processed by the challenge server:
+Get the history of HTTP requests processed by the challenge server:
 ```
-requestHistory := challSrv.RequestHistory()
+requestHistory := challSrv.RequestHistory(challtestsrv.HTTPRequestEventType)
 ```
 
-Clear the history of requests:
+Clear the history of HTTP requests processed by the challenge server:
 ```
-challSrv.ClearRequestHistory()
+challSrv.ClearRequestHistory(challtestsrv.HTTPRequestEventType)
 ```
 
 Stop the Challenge server and subservers:

--- a/README.md
+++ b/README.md
@@ -50,14 +50,16 @@ value `"bbb"`, defer cleaning it up again:
   defer challSrv.DeleteHTTPOneChallenge("_acme-challenge.example.com.")
 ```
 
-Get the history of HTTP requests processed by the challenge server:
+Get the history of HTTP requests processed by the challenge server for the host
+"example.com":
 ```
-requestHistory := challSrv.RequestHistory(challtestsrv.HTTPRequestEventType)
+requestHistory := challSrv.RequestHistory("example.com", challtestsrv.HTTPRequestEventType)
 ```
 
-Clear the history of HTTP requests processed by the challenge server:
+Clear the history of HTTP requests processed by the challenge server for the
+host "example.com":
 ```
-challSrv.ClearRequestHistory(challtestsrv.HTTPRequestEventType)
+challSrv.ClearRequestHistory("example.com", challtestsrv.HTTPRequestEventType)
 ```
 
 Stop the Challenge server and subservers:

--- a/challenge-servers.go
+++ b/challenge-servers.go
@@ -35,9 +35,9 @@ type ChallSrv struct {
 	// response data maps below.
 	challMu sync.RWMutex
 
-	// requestHistory is a map from event type to a list of sequential request
-	// events
-	requestHistory map[RequestEventType][]RequestEvent
+	// requestHistory is a map from hostname to a map of event type to a list of
+	// sequential request events
+	requestHistory map[string]map[RequestEventType][]RequestEvent
 
 	// httpOne is a map of token values to key authorizations used for HTTP-01
 	// responses.
@@ -125,7 +125,7 @@ func New(config Config) (*ChallSrv, error) {
 
 	challSrv := &ChallSrv{
 		log:            config.Log,
-		requestHistory: make(map[RequestEventType][]RequestEvent),
+		requestHistory: make(map[string]map[RequestEventType][]RequestEvent),
 		httpOne:        make(map[string]string),
 		dnsOne:         make(map[string][]string),
 		tlsALPNOne:     make(map[string]string),

--- a/challenge-servers.go
+++ b/challenge-servers.go
@@ -35,10 +35,9 @@ type ChallSrv struct {
 	// response data maps below.
 	challMu sync.RWMutex
 
-	// requestHistory is a sequential list of request events processed by
-	// challenge servers. It can be cleared with the
-	// `ChallSrv.ClearRequestHistory` function.
-	requestHistory []RequestEvent
+	// requestHistory is a map from event type to a list of sequential request
+	// events
+	requestHistory map[RequestEventType][]RequestEvent
 
 	// httpOne is a map of token values to key authorizations used for HTTP-01
 	// responses.
@@ -126,7 +125,7 @@ func New(config Config) (*ChallSrv, error) {
 
 	challSrv := &ChallSrv{
 		log:            config.Log,
-		requestHistory: []RequestEvent{},
+		requestHistory: make(map[RequestEventType][]RequestEvent),
 		httpOne:        make(map[string]string),
 		dnsOne:         make(map[string][]string),
 		tlsALPNOne:     make(map[string]string),

--- a/challenge-servers.go
+++ b/challenge-servers.go
@@ -126,7 +126,7 @@ func New(config Config) (*ChallSrv, error) {
 
 	challSrv := &ChallSrv{
 		log:            config.Log,
-		requestHistory: make([]RequestEvent),
+		requestHistory: []RequestEvent{},
 		httpOne:        make(map[string]string),
 		dnsOne:         make(map[string][]string),
 		tlsALPNOne:     make(map[string]string),

--- a/challenge-servers.go
+++ b/challenge-servers.go
@@ -35,6 +35,11 @@ type ChallSrv struct {
 	// response data maps below.
 	challMu sync.RWMutex
 
+	// requestHistory is a sequential list of request events processed by
+	// challenge servers. It can be cleared with the
+	// `ChallSrv.ClearRequestHistory` function.
+	requestHistory []RequestEvent
+
 	// httpOne is a map of token values to key authorizations used for HTTP-01
 	// responses.
 	httpOne map[string]string
@@ -120,11 +125,12 @@ func New(config Config) (*ChallSrv, error) {
 	}
 
 	challSrv := &ChallSrv{
-		log:        config.Log,
-		httpOne:    make(map[string]string),
-		dnsOne:     make(map[string][]string),
-		tlsALPNOne: make(map[string]string),
-		redirects:  make(map[string]string),
+		log:            config.Log,
+		requestHistory: make([]RequestEvent),
+		httpOne:        make(map[string]string),
+		dnsOne:         make(map[string][]string),
+		tlsALPNOne:     make(map[string]string),
+		redirects:      make(map[string]string),
 		dnsMocks: mockDNSData{
 			defaultIPv4: defaultIPv4,
 			defaultIPv6: defaultIPv6,

--- a/dns.go
+++ b/dns.go
@@ -2,7 +2,6 @@ package challtestsrv
 
 import (
 	"net"
-	"time"
 
 	"github.com/miekg/dns"
 )
@@ -144,7 +143,6 @@ func (s *ChallSrv) dnsHandler(w dns.ResponseWriter, r *dns.Msg) {
 	// For each question, add answers based on the type of question
 	for _, q := range r.Question {
 		s.AddRequestEvent(DNSRequestEvent{
-			Time:     time.Now(),
 			Question: q,
 		})
 		var answerFunc dnsAnswerFunc

--- a/dns.go
+++ b/dns.go
@@ -2,6 +2,7 @@ package challtestsrv
 
 import (
 	"net"
+	"time"
 
 	"github.com/miekg/dns"
 )
@@ -142,6 +143,10 @@ func (s *ChallSrv) dnsHandler(w dns.ResponseWriter, r *dns.Msg) {
 
 	// For each question, add answers based on the type of question
 	for _, q := range r.Question {
+		s.AddRequestEvent(DNSRequestEvent{
+			Time:     time.Now(),
+			Question: q,
+		})
 		var answerFunc dnsAnswerFunc
 		switch q.Qtype {
 		case dns.TypeTXT:

--- a/event.go
+++ b/event.go
@@ -28,6 +28,9 @@ type HTTPRequestEvent struct {
 	Path string
 	// Whether the request was received over HTTPS or HTTP
 	HTTPS bool
+	// The ServerName from the ClientHello. May be empty if there was no SNI or if
+	// the request was not HTTPS
+	ServerName string
 }
 
 // An HTTPRequestEvent is String formatted as:

--- a/event.go
+++ b/event.go
@@ -1,0 +1,97 @@
+package challtestsrv
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+// RequestEvent is an interface used to handle disparate request event types in
+// a uniform list.
+type RequestEvent interface {
+	String() string
+}
+
+// HTTPRequestEvent corresponds to an HTTP request received by a httpOneServer.
+type HTTPRequestEvent struct {
+	// Time the request was received
+	Time time.Time
+	// The full request URL (path and query arguments)
+	URL string
+	// The Host header from the request
+	Host string
+	// The request Method (POST, GET, HEAD, etc)
+	Method string
+	// The request path
+	Path string
+	// Whether the request was received over HTTPS or HTTP
+	HTTPS bool
+}
+
+// An HTTPRequestEvent is String formatted as:
+// <timestamp> - HTTP|HTTPS - <Method> - <Host> - <URL>
+func (e HTTPRequestEvent) String() string {
+	timeStamp := e.Time.Format(time.RFC3339)
+	protocol := "HTTP"
+	if e.HTTPS {
+		protocol = "HTTPS"
+	}
+	return fmt.Sprintf("%s - %s - %s - %s - %s", timeStamp, protocol, e.Method, e.Host, e.URL)
+}
+
+// DNSRequestEvent corresponds to a DNS request received by a dnsOneServer.
+type DNSRequestEvent struct {
+	// Time request was received.
+	Time time.Time
+	// The DNS question received.
+	Question dns.Question
+}
+
+// A DNSRequestEvent is String formatted as:
+// <timestamp> - DNS - "<query>"
+func (e DNSRequestEvent) String() string {
+	timeStamp := e.Time.Format(time.RFC3339)
+	return fmt.Sprintf("%s - DNS - %q", timeStamp, e.Question.String())
+}
+
+// TLSALPNRequestEvent corresponds to a TLS request received by
+// a tlsALPNOneServer.
+type TLSALPNRequestEvent struct {
+	// Time request was received.
+	Time time.Time
+	// ServerName from the TLS Client Hello.
+	ServerName string
+	// SupportedProtos from the TLS Client Hello.
+	SupportedProtos []string
+}
+
+// A TLSALPNRequestEvent is String formatted as:
+// <timestamp> - TLS-ALPN-01 - <servername> - <comma separated supported protos>
+func (e TLSALPNRequestEvent) String() string {
+	timeStamp := e.Time.Format(time.RFC3339)
+	return fmt.Sprintf("%s - TLS-ALPN-01 - %s - %s",
+		timeStamp, e.ServerName, strings.Join(e.SupportedProtos, ","))
+}
+
+// AddRequestEvent appends a RequestEvent to the server's request history.
+func (s *ChallSrv) AddRequestEvent(event RequestEvent) {
+	s.challMu.Lock()
+	defer s.challMu.Unlock()
+	s.requestHistory = append(s.requestHistory, event)
+}
+
+// RequestHistory returns the server's request history.
+func (s *ChallSrv) RequestHistory() []RequestEvent {
+	s.challMu.RLock()
+	defer s.challMu.RUnlock()
+	return s.requestHistory
+}
+
+// ClearRequestHistory clears the server's request history.
+func (s *ChallSrv) ClearRequestHistory() {
+	s.challMu.Lock()
+	defer s.challMu.Unlock()
+	s.requestHistory = []RequestEvent{}
+}

--- a/event.go
+++ b/event.go
@@ -1,10 +1,6 @@
 package challtestsrv
 
-import (
-	"time"
-
-	"github.com/miekg/dns"
-)
+import "github.com/miekg/dns"
 
 // RequestEventType indicates what type of event occurred.
 type RequestEventType int
@@ -18,24 +14,20 @@ const (
 	TLSALPNRequestEventType
 )
 
-// A RequestEvent is anything that can identify its RequestEventType
+// A RequestEvent is anything that can identify its RequestEventType and a key
+// for storing the request event in the history.
 type RequestEvent interface {
 	Type() RequestEventType
+	Key() string
 }
 
 // HTTPRequestEvent corresponds to an HTTP request received by a httpOneServer.
 // It implements the RequestEvent interface.
 type HTTPRequestEvent struct {
-	// Time the request was received
-	Time time.Time
 	// The full request URL (path and query arguments)
 	URL string
 	// The Host header from the request
 	Host string
-	// The request Method (POST, GET, HEAD, etc)
-	Method string
-	// The request path
-	Path string
 	// Whether the request was received over HTTPS or HTTP
 	HTTPS bool
 	// The ServerName from the ClientHello. May be empty if there was no SNI or if
@@ -48,11 +40,14 @@ func (e HTTPRequestEvent) Type() RequestEventType {
 	return HTTPRequestEventType
 }
 
+// HTTPRequestEvents use the HTTP Host as the storage key
+func (e HTTPRequestEvent) Key() string {
+	return e.Host
+}
+
 // DNSRequestEvent corresponds to a DNS request received by a dnsOneServer. It
 // implements the RequestEvent interface.
 type DNSRequestEvent struct {
-	// Time request was received.
-	Time time.Time
 	// The DNS question received.
 	Question dns.Question
 }
@@ -62,11 +57,14 @@ func (e DNSRequestEvent) Type() RequestEventType {
 	return DNSRequestEventType
 }
 
+// DNSRequestEvents use the Question Name as the storage key
+func (e DNSRequestEvent) Key() string {
+	return e.Question.Name
+}
+
 // TLSALPNRequestEvent corresponds to a TLS request received by
 // a tlsALPNOneServer. It implements the RequestEvent interface.
 type TLSALPNRequestEvent struct {
-	// Time request was received.
-	Time time.Time
 	// ServerName from the TLS Client Hello.
 	ServerName string
 	// SupportedProtos from the TLS Client Hello.
@@ -78,6 +76,11 @@ func (e TLSALPNRequestEvent) Type() RequestEventType {
 	return TLSALPNRequestEventType
 }
 
+// TLSALPNRequestEvents use the SNI value as the storage key
+func (e TLSALPNRequestEvent) Key() string {
+	return e.ServerName
+}
+
 // AddRequestEvent adds a RequestEvent to the server's request history. It is
 // appeneded to a list of RequestEvents indexed by the event's Type().
 func (s *ChallSrv) AddRequestEvent(event RequestEvent) {
@@ -85,20 +88,32 @@ func (s *ChallSrv) AddRequestEvent(event RequestEvent) {
 	defer s.challMu.Unlock()
 
 	typ := event.Type()
-	s.requestHistory[typ] = append(s.requestHistory[typ], event)
+	host := event.Key()
+	if s.requestHistory[host] == nil {
+		s.requestHistory[host] = make(map[RequestEventType][]RequestEvent)
+	}
+	s.requestHistory[host][typ] = append(s.requestHistory[host][typ], event)
 }
 
-// RequestHistory returns the server's request history for the given event type.
-func (s *ChallSrv) RequestHistory(typ RequestEventType) []RequestEvent {
+// RequestHistory returns the server's request history for the given hostname
+// and event type.
+func (s *ChallSrv) RequestHistory(hostname string, typ RequestEventType) []RequestEvent {
 	s.challMu.RLock()
 	defer s.challMu.RUnlock()
-	return s.requestHistory[typ]
+
+	if hostEvents, ok := s.requestHistory[hostname]; ok {
+		return hostEvents[typ]
+	}
+	return []RequestEvent{}
 }
 
-// ClearRequestHistory clears the server's request history for the given event
-// type.
-func (s *ChallSrv) ClearRequestHistory(typ RequestEventType) {
+// ClearRequestHistory clears the server's request history for the given
+// hostname and event type.
+func (s *ChallSrv) ClearRequestHistory(hostname string, typ RequestEventType) {
 	s.challMu.Lock()
 	defer s.challMu.Unlock()
-	s.requestHistory[typ] = []RequestEvent{}
+
+	if hostEvents, ok := s.requestHistory[hostname]; ok {
+		hostEvents[typ] = []RequestEvent{}
+	}
 }

--- a/event.go
+++ b/event.go
@@ -1,7 +1,6 @@
 package challtestsrv
 
 import (
-	"fmt"
 	"net"
 	"strings"
 

--- a/httpone.go
+++ b/httpone.go
@@ -124,11 +124,8 @@ func (s *ChallSrv) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	s.AddRequestEvent(HTTPRequestEvent{
-		Time:       time.Now(),
 		URL:        r.URL.String(),
 		Host:       r.Host,
-		Method:     r.Method,
-		Path:       requestPath,
 		HTTPS:      r.TLS != nil,
 		ServerName: serverName,
 	})

--- a/httpone.go
+++ b/httpone.go
@@ -118,13 +118,19 @@ func (s *ChallSrv) GetHTTPRedirect(path string) (string, bool) {
 func (s *ChallSrv) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	requestPath := r.URL.Path
 
+	serverName := ""
+	if r.TLS != nil {
+		serverName = r.TLS.ServerName
+	}
+
 	s.AddRequestEvent(HTTPRequestEvent{
-		Time:   time.Now(),
-		URL:    r.URL.String(),
-		Host:   r.Host,
-		Method: r.Method,
-		Path:   requestPath,
-		HTTPS:  r.TLS != nil,
+		Time:       time.Now(),
+		URL:        r.URL.String(),
+		Host:       r.Host,
+		Method:     r.Method,
+		Path:       requestPath,
+		HTTPS:      r.TLS != nil,
+		ServerName: serverName,
 	})
 
 	// If the request was not over HTTPS and we have a redirect, serve it.

--- a/httpone.go
+++ b/httpone.go
@@ -49,7 +49,7 @@ func selfSignedCert() tls.Certificate {
 		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
 		BasicConstraintsValid: true,
-		IsCA: true,
+		IsCA:                  true,
 	}
 
 	der, err := x509.CreateCertificate(rand.Reader, template, template, key.Public(), key)
@@ -117,6 +117,15 @@ func (s *ChallSrv) GetHTTPRedirect(path string) (string, bool) {
 // then the challenge response contents are returned.
 func (s *ChallSrv) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	requestPath := r.URL.Path
+
+	s.AddRequestEvent(HTTPRequestEvent{
+		Time:   time.Now(),
+		URL:    r.URL.String(),
+		Host:   r.Host,
+		Method: r.Method,
+		Path:   requestPath,
+		HTTPS:  r.TLS != nil,
+	})
 
 	// If the request was not over HTTPS and we have a redirect, serve it.
 	// Redirects are ignored over HTTPS so we can easily do an HTTP->HTTPS

--- a/tlsalpnone.go
+++ b/tlsalpnone.go
@@ -51,7 +51,6 @@ func (s *ChallSrv) GetTLSALPNChallenge(host string) (string, bool) {
 func (s *ChallSrv) ServeChallengeCertFunc(k *ecdsa.PrivateKey) func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
 	return func(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
 		s.AddRequestEvent(TLSALPNRequestEvent{
-			Time:            time.Now(),
 			ServerName:      hello.ServerName,
 			SupportedProtos: hello.SupportedProtos,
 		})

--- a/tlsalpnone.go
+++ b/tlsalpnone.go
@@ -50,6 +50,11 @@ func (s *ChallSrv) GetTLSALPNChallenge(host string) (string, bool) {
 
 func (s *ChallSrv) ServeChallengeCertFunc(k *ecdsa.PrivateKey) func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
 	return func(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
+		s.AddRequestEvent(TLSALPNRequestEvent{
+			Time:            time.Now(),
+			ServerName:      hello.ServerName,
+			SupportedProtos: hello.SupportedProtos,
+		})
 		if len(hello.SupportedProtos) != 1 || hello.SupportedProtos[0] != ACMETLS1Protocol {
 			return nil, fmt.Errorf(
 				"ALPN failed, ClientHelloInfo.SupportedProtos: %s",


### PR DESCRIPTION
Its useful for testing purposes to be able to find out what requests have been processed by the challenge test servers.

For example it may be useful to see that redirects were properly followed or that CAA tree climbing resulted in the expected DNS queries.