### PR TITLE
fix: don't panic with unknown DNS question type.

### DIFF
--- a/challenge-servers.go
+++ b/challenge-servers.go
@@ -60,7 +60,7 @@ type ChallSrv struct {
 	redirects map[string]string
 }
 
-// mockDNSData holds mock respones for DNS A, AAAA, and CAA lookups.
+// mockDNSData holds mock responses for DNS A, AAAA, and CAA lookups.
 type mockDNSData struct {
 	// The IPv4 address used for all A record responses that don't match a host in
 	// aRecords.
@@ -68,7 +68,7 @@ type mockDNSData struct {
 	// The IPv6 address used for all AAAA record responses that don't match a host
 	// in aaaaRecords.
 	defaultIPv6 string
-	// A map of host to IPv4 addressess in string form for A record responses.
+	// A map of host to IPv4 addresses in string form for A record responses.
 	aRecords map[string][]string
 	// A map of host to IPv6 addresses in string form for AAAA record responses.
 	aaaaRecords map[string][]string

--- a/dns.go
+++ b/dns.go
@@ -145,6 +145,7 @@ func (s *ChallSrv) dnsHandler(w dns.ResponseWriter, r *dns.Msg) {
 		s.AddRequestEvent(DNSRequestEvent{
 			Question: q,
 		})
+
 		var answerFunc dnsAnswerFunc
 		switch q.Qtype {
 		case dns.TypeTXT:
@@ -155,7 +156,14 @@ func (s *ChallSrv) dnsHandler(w dns.ResponseWriter, r *dns.Msg) {
 			answerFunc = s.aaaaAnswers
 		case dns.TypeCAA:
 			answerFunc = s.caaAnswers
+		default:
+			m.SetRcode(r, dns.RcodeNotImplemented)
 		}
+
+		if answerFunc == nil {
+			break
+		}
+
 		if records := answerFunc(q); len(records) > 0 {
 			m.Answer = append(m.Answer, records...)
 		}

--- a/httpone.go
+++ b/httpone.go
@@ -95,7 +95,7 @@ func (s *ChallSrv) AddHTTPRedirect(path, targetURL string) {
 	s.redirects[path] = targetURL
 }
 
-// DeletedHTTPRedirect deletes a redirect for the given path.
+// DeleteHTTPRedirect deletes a redirect for the given path.
 func (s *ChallSrv) DeleteHTTPRedirect(path string) {
 	s.challMu.Lock()
 	defer s.challMu.Unlock()

--- a/mockdns.go
+++ b/mockdns.go
@@ -1,7 +1,7 @@
 package challtestsrv
 
 import (
-	"strings"
+	"github.com/miekg/dns"
 )
 
 // SetDefaultDNSIPv4 sets the default IPv4 address used for A query responses
@@ -43,9 +43,7 @@ func (s *ChallSrv) GetDefaultDNSIPv6() string {
 func (s *ChallSrv) AddDNSARecord(host string, addresses []string) {
 	s.challMu.Lock()
 	defer s.challMu.Unlock()
-	if !strings.HasSuffix(host, ".") {
-		host = host + "."
-	}
+	host = dns.Fqdn(host)
 	s.dnsMocks.aRecords[host] = append(s.dnsMocks.aRecords[host], addresses...)
 }
 
@@ -54,9 +52,7 @@ func (s *ChallSrv) AddDNSARecord(host string, addresses []string) {
 func (s *ChallSrv) DeleteDNSARecord(host string) {
 	s.challMu.Lock()
 	defer s.challMu.Unlock()
-	if !strings.HasSuffix(host, ".") {
-		host = host + "."
-	}
+	host = dns.Fqdn(host)
 	delete(s.dnsMocks.aRecords, host)
 }
 
@@ -64,9 +60,7 @@ func (s *ChallSrv) DeleteDNSARecord(host string) {
 // returned when querying for A records for the given host.
 func (s *ChallSrv) GetDNSARecord(host string) []string {
 	s.challMu.RLock()
-	if !strings.HasSuffix(host, ".") {
-		host = host + "."
-	}
+	host = dns.Fqdn(host)
 	defer s.challMu.RUnlock()
 	return s.dnsMocks.aRecords[host]
 }
@@ -76,9 +70,7 @@ func (s *ChallSrv) GetDNSARecord(host string) []string {
 func (s *ChallSrv) AddDNSAAAARecord(host string, addresses []string) {
 	s.challMu.Lock()
 	defer s.challMu.Unlock()
-	if !strings.HasSuffix(host, ".") {
-		host = host + "."
-	}
+	host = dns.Fqdn(host)
 	s.dnsMocks.aaaaRecords[host] = append(s.dnsMocks.aaaaRecords[host], addresses...)
 }
 
@@ -87,9 +79,7 @@ func (s *ChallSrv) AddDNSAAAARecord(host string, addresses []string) {
 func (s *ChallSrv) DeleteDNSAAAARecord(host string) {
 	s.challMu.Lock()
 	defer s.challMu.Unlock()
-	if !strings.HasSuffix(host, ".") {
-		host = host + "."
-	}
+	host = dns.Fqdn(host)
 	delete(s.dnsMocks.aaaaRecords, host)
 }
 
@@ -98,9 +88,7 @@ func (s *ChallSrv) DeleteDNSAAAARecord(host string) {
 func (s *ChallSrv) GetDNSAAAARecord(host string) []string {
 	s.challMu.RLock()
 	defer s.challMu.RUnlock()
-	if !strings.HasSuffix(host, ".") {
-		host = host + "."
-	}
+	host = dns.Fqdn(host)
 	return s.dnsMocks.aaaaRecords[host]
 }
 
@@ -109,9 +97,7 @@ func (s *ChallSrv) GetDNSAAAARecord(host string) []string {
 func (s *ChallSrv) AddDNSCAARecord(host string, policies []MockCAAPolicy) {
 	s.challMu.Lock()
 	defer s.challMu.Unlock()
-	if !strings.HasSuffix(host, ".") {
-		host = host + "."
-	}
+	host = dns.Fqdn(host)
 	s.dnsMocks.caaRecords[host] = append(s.dnsMocks.caaRecords[host], policies...)
 }
 
@@ -120,9 +106,7 @@ func (s *ChallSrv) AddDNSCAARecord(host string, policies []MockCAAPolicy) {
 func (s *ChallSrv) DeleteDNSCAARecord(host string) {
 	s.challMu.Lock()
 	defer s.challMu.Unlock()
-	if !strings.HasSuffix(host, ".") {
-		host = host + "."
-	}
+	host = dns.Fqdn(host)
 	delete(s.dnsMocks.caaRecords, host)
 }
 
@@ -131,8 +115,6 @@ func (s *ChallSrv) DeleteDNSCAARecord(host string) {
 func (s *ChallSrv) GetDNSCAARecord(host string) []MockCAAPolicy {
 	s.challMu.RLock()
 	defer s.challMu.RUnlock()
-	if !strings.HasSuffix(host, ".") {
-		host = host + "."
-	}
+	host = dns.Fqdn(host)
 	return s.dnsMocks.caaRecords[host]
 }


### PR DESCRIPTION
Currently when a question type is not supported challtestsrc panics.

My fix is a possibility but it's also possible:
- to panic with a clear message
- to skip (continue)

Tell me what you prefer.

```bash
dig @localhost -p 8053 SOA foobar.com
# or
drill foobar.com SOA @localhost -p 8053
```

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x6d0967]

goroutine 40 [running]:
github.com/letsencrypt/pebble/vendor/github.com/letsencrypt/challtestsrv.(*ChallSrv).dnsHandler(0xc0000a4be0, 0x7ee6c0, 0xc0001f8080, 0xc00023e000)
	/home/ldez/sources/go/src/github.com/letsencrypt/pebble/vendor/github.com/letsencrypt/challtestsrv/dns.go:159 +0x1f7
github.com/letsencrypt/pebble/vendor/github.com/letsencrypt/challtestsrv.(*ChallSrv).dnsHandler-fm(0x7ee6c0, 0xc0001f8080, 0xc00023e000)
	/home/ldez/sources/go/src/github.com/letsencrypt/pebble/vendor/github.com/letsencrypt/challtestsrv/challenge-servers.go:160 +0x48
github.com/letsencrypt/pebble/vendor/github.com/miekg/dns.HandlerFunc.ServeDNS(0xc0000a3180, 0x7ee6c0, 0xc0001f8080, 0xc00023e000)
	/home/ldez/sources/go/src/github.com/letsencrypt/pebble/vendor/github.com/miekg/dns/server.go:52 +0x44
github.com/letsencrypt/pebble/vendor/github.com/miekg/dns.(*ServeMux).ServeDNS(0xc0000c0320, 0x7ee6c0, 0xc0001f8080, 0xc00023e000)
	/home/ldez/sources/go/src/github.com/letsencrypt/pebble/vendor/github.com/miekg/dns/serve_mux.go:128 +0x5d
github.com/letsencrypt/pebble/vendor/github.com/miekg/dns.(*Server).serveDNS(0xc00016e000, 0xc0001f8080)
	/home/ldez/sources/go/src/github.com/letsencrypt/pebble/vendor/github.com/miekg/dns/server.go:688 +0x2c1
github.com/letsencrypt/pebble/vendor/github.com/miekg/dns.(*Server).serve(0xc00016e000, 0xc0001f8080)
	/home/ldez/sources/go/src/github.com/letsencrypt/pebble/vendor/github.com/miekg/dns/server.go:573 +0x2d8
github.com/letsencrypt/pebble/vendor/github.com/miekg/dns.(*Server).worker(0xc00016e000, 0xc0001f8080)
	/home/ldez/sources/go/src/github.com/letsencrypt/pebble/vendor/github.com/miekg/dns/server.go:244 +0x4d
created by github.com/letsencrypt/pebble/vendor/github.com/miekg/dns.(*Server).spawnWorker
	/home/ldez/sources/go/src/github.com/letsencrypt/pebble/vendor/github.com/miekg/dns/server.go:284 +0x86
```