### PR TITLE
Add linting, README badges, code coverage, code of conduct.

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,22 @@
+linters-settings:
+  gocyclo:
+    min-complexity: 25
+  govet:
+    check-shadowing: false
+  misspell:
+    locale: "US"
+
+linters:
+  enable-all: true
+  disable:
+    - stylecheck
+    - gosec
+    - dupl
+    - maligned
+    - depguard
+    - lll
+    - prealloc
+    - scopelint
+    - gocritic
+    - gochecknoinits
+    - gochecknoglobals

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,17 @@ env:
 # Override the base install phase so that the project can be installed using
 # `-mod=vendor` to use the vendored dependencies
 install:
+  # Install `golangci-lint` using their installer script
+  - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.13.2
+  # Install `cover` and `goveralls` without `GO111MODULE` enabled so that we
+  # don't download project dependencies and just put the tools in $GOPATH/bin
+  - GO111MODULE=off go get golang.org/x/tools/cmd/cover
+  - GO111MODULE=off go get github.com/mattn/goveralls
   - go install -mod=vendor -v -race ./...
 
 script:
-  - go vet -mod=vendor -v ./...
-  - go test -mod=vendor -v -race ./...
+  - set -e
+  - go mod download
+  - golangci-lint run
+  - go test -mod=vendor -v -race -covermode=atomic -coverprofile=coverage.out ./...
+  - goveralls -coverprofile=coverage.out -service=travis-ci

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# Contributor Code of Conduct
+
+The contributor code of conduct is available for reference [on the community forum](https://community.letsencrypt.org/guidelines).

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Challenge Test Server
 
+[![Build Status](https://travis-ci.org/letsencrypt/challtestsrv.svg?branch=master)](https://travis-ci.org/letsencrypt/challtestsrv)
+[![Coverage Status](https://coveralls.io/repos/github/letsencrypt/challtestsrv/badge.svg)](https://coveralls.io/github/letsencrypt/challtestsrv)
+[![Go Report Card](https://goreportcard.com/badge/github.com/letsencrypt/challtestsrv)](https://goreportcard.com/report/github.com/letsencrypt/challtestsrv)
+[![GolangCI](https://golangci.com/badges/github.com/letsencrypt/challtestsrv.svg)](https://golangci.com/r/github.com/letsencrypt/challtestsrv)
+
 The `challtestsrv` package offers a library/command that can be used by test
 code to respond to HTTP-01, DNS-01, and TLS-ALPN-01 ACME challenges. The
 `challtestsrv` package can also be used as a mock DNS server letting

--- a/tlsalpnone.go
+++ b/tlsalpnone.go
@@ -20,7 +20,8 @@ import (
 // https://tools.ietf.org/html/draft-ietf-acme-tls-alpn-01#section-5.2
 const ACMETLS1Protocol = "acme-tls/1"
 
-// As defined in https://tools.ietf.org/html/draft-ietf-acme-tls-alpn-04#section-5.1
+// IdPeAcmeIdentifier is the identifier defined in
+// https://tools.ietf.org/html/draft-ietf-acme-tls-alpn-04#section-5.1
 // id-pe OID + 31 (acmeIdentifier)
 var IdPeAcmeIdentifier = asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 1, 31}
 

--- a/tlsalpnone.go
+++ b/tlsalpnone.go
@@ -20,10 +20,10 @@ import (
 // https://tools.ietf.org/html/draft-ietf-acme-tls-alpn-01#section-5.2
 const ACMETLS1Protocol = "acme-tls/1"
 
-// IdPeAcmeIdentifier is the identifier defined in
+// IDPeAcmeIdentifier is the identifier defined in
 // https://tools.ietf.org/html/draft-ietf-acme-tls-alpn-04#section-5.1
 // id-pe OID + 31 (acmeIdentifier)
-var IdPeAcmeIdentifier = asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 1, 31}
+var IDPeAcmeIdentifier = asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 1, 31}
 
 // AddTLSALPNChallenge adds a new TLS-ALPN-01 key authorization for the given host
 func (s *ChallSrv) AddTLSALPNChallenge(host, content string) {
@@ -76,7 +76,7 @@ func (s *ChallSrv) ServeChallengeCertFunc(k *ecdsa.PrivateKey) func(*tls.ClientH
 			DNSNames:     []string{hello.ServerName},
 			ExtraExtensions: []pkix.Extension{
 				{
-					Id:       IdPeAcmeIdentifier,
+					Id:       IDPeAcmeIdentifier,
 					Critical: true,
 					Value:    extValue,
 				},


### PR DESCRIPTION
This PR breaks API compatibility by renaming the exported `IdPeAcmeIdentifier` field to `IDPeAcmeIdentifier`.

I'll cut a new major release the next time something beyond tidying up comes along.