### PR TITLE
Avoid logging on a clean server shutdown.

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -23,7 +23,6 @@ linters:
     - gomnd
     - wsl
     - goerr113
-    - nlreturn
     - godot
 
 issues:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -22,6 +22,9 @@ linters:
     - gochecknoglobals
     - gomnd
     - wsl
+    - goerr113
+    - nlreturn
+    - godot
 
 issues:
   exclude-use-default: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ cache:
 # `-mod=vendor` to use the vendored dependencies
 install:
   # Install `golangci-lint` using their installer script
-  - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.23.3
+  - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.29.0
   # Install `cover` and `goveralls` without `GO111MODULE` enabled so that we
   # don't download project dependencies and just put the tools in $GOPATH/bin
   - GO111MODULE=off go get golang.org/x/tools/cmd/cover

--- a/challenge-servers.go
+++ b/challenge-servers.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
 	"sync"
 )
 
@@ -183,7 +184,7 @@ func (s *ChallSrv) Run() {
 	for _, srv := range s.servers {
 		go func(srv challengeServer) {
 			err := srv.ListenAndServe()
-			if err != nil {
+			if err != nil && !strings.Contains(err.Error(), "Server closed") {
 				s.log.Print(err)
 			}
 		}(srv)


### PR DESCRIPTION
Go's `ListenAndServe` methods return an error with the text "Server
close", even on a clean shutdown. We should suppress this spurious error
so it doesn't mask more meaningful ones.

Also, update to a more recent golangci-lint and exempt some lints in order
to fix the build.