### PR TITLE
Split long TXT record values into RFC 1035-compliant chunks

### DIFF
--- a/dns.go
+++ b/dns.go
@@ -265,10 +265,13 @@ func splitTXTRecordValue(value string) []string {
 		return []string{value}
 	}
 
-	chunks := make([]string, 0, (len(value)+maxTXTStringOctets-1)/maxTXTStringOctets)
-	for start := 0; start < len(value); start += maxTXTStringOctets {
-		end := min(start+maxTXTStringOctets, len(value))
-		chunks = append(chunks, value[start:end])
+	var chunks []string
+	for len(value) > maxTXTStringOctets {
+		chunks = append(chunks, value[:maxTXTStringOctets])
+		value = value[maxTXTStringOctets:]
+	}
+	if len(value) > 0 {
+		chunks = append(chunks, value)
 	}
 	return chunks
 }


### PR DESCRIPTION
Ensure TXT record values longer than 255 octets are split into multiple RFC 1035 character-string segments when building DNS answers.