### PR TITLE
dns: set AA flag on responses

### DIFF
--- a/dns.go
+++ b/dns.go
@@ -432,6 +432,9 @@ func (s *ChallSrv) dnsHandlerInner(w writeMsg, r *dns.Msg, userAgent string) {
 	m := new(dns.Msg)
 	m.SetReply(r)
 	m.Compress = false
+	// AA: challtestsrv is the authoritative server for every name it answers
+	// (RFC 1035 §4.1.1).
+	m.Authoritative = true
 
 	// For each question, add answers based on the type of question
 	for _, q := range r.Question {


### PR DESCRIPTION
challtestsrv is authoritative for every name it answers and synthesizes its own SOA in the AUTHORITY section, so replies must have the AA bit set per RFC 1035 4.1.1. Without it, AA=0 + an authoritative SOA is an internally inconsistent response that DNSSEC validators and strict test harnesses can flag.

And that's exactly how I hit this - my test verifies AA flag.